### PR TITLE
Windows compatibility

### DIFF
--- a/R/DataCache.R
+++ b/R/DataCache.R
@@ -63,7 +63,7 @@ data.cache <- function(FUN,
 		cache.dir <- normalizePath(cache.dir)
 	}
 	cinfo <- cache.info(cache.dir=cache.dir, cache.name=cache.name, stale=NULL)
-	new.cache.file <- paste0(cache.dir, '/', cache.name, cache.date, '.rda')
+	new.cache.file <- paste0(cache.dir, '/', cache.name, format(cache.date, format='%Y%m%d-%H%M%S'), '.rda')
 	
 	if(nrow(cinfo) > 0 & Sys.info()['sysname'] != 'Windows' & !wait) {
 		if(frequency(cinfo[1,]$created)) { # Check to see if the cache is stale
@@ -80,7 +80,7 @@ data.cache <- function(FUN,
 # 				}
 # 				p <- mcfork(estranged=TRUE) # Using interal copy of function
 				if(inherits(p, "masterProcess")) {
-					sink(file=paste0(cache.dir, '/', cache.name, cache.date, '.log'), append=TRUE)
+					sink(file=paste0(cache.dir, '/', cache.name, format(cache.date, format='%Y%m%d-%H%M%S'), '.log'), append=TRUE)
 					print(paste0('Loading data at ', Sys.time()))
 					tryCatch({
 							thedata <- FUN(...)
@@ -122,7 +122,7 @@ data.cache <- function(FUN,
 		} else {
 			message('No cached data found. Loading intial data...')
 		}
-		sink(file=paste0(cache.dir, '/', cache.name, cache.date, '.log'), append=TRUE)
+		sink(file=paste0(cache.dir, '/', cache.name, format(cache.date, format='%Y%m%d-%H%M%S'), '.log'), append=TRUE)
 		print(paste0('Loading data at ', Sys.time()))
 		thedata <- FUN(...)
 		if(class(thedata) == 'list') {

--- a/R/cacheInfo.R
+++ b/R/cacheInfo.R
@@ -24,8 +24,9 @@ cache.info <- function(cache.dir='cache', cache.name='Cache', units='mins',
 			timestamps <- substr(cache.files, 
 								 nchar(cache.name) + 1,
 								 sapply(cache.files, nchar) - 4)
+			timestamps <- as.POSIXct(timestamps, format='%Y%m%d-%H%M%S')
 			results <- data.frame(file=cache.files,
-								  created=as.POSIXct(timestamps),
+								  created=timestamps,
 								  age=as.numeric(difftime(Sys.time(), timestamps, units=units)))
 			names(results)[3] <- paste0('age_', units)
 			if(!is.null(stale)) {


### PR DESCRIPTION
I'm using your package on Windows and encountered two issues:
1) The cache file names include colon characters (:) from the timestamp. Windows doesn't accept colons in filenames
2) Caching is skipped on Windows. I would like to have synchronous caching enabled.

I've solved both issues for my own purposes: number 1 by using a date format in the file names and number 2 by changing the if statement. Please consider merging these changes.
